### PR TITLE
Standardize package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,18 +1,27 @@
 {
   "name": "suitcss-components-button",
-  "description": "Structural button styles for SUIT CSS",
   "version": "5.0.0",
-  "style": "index.css",
+  "description": "Structural button styles for SUIT CSS",
+  "keywords": [
+    "browser",
+    "css-components",
+    "button",
+    "suitcss",
+    "style"
+  ],
+  "homepage": "https://github.com/suitcss/components-button#readme",
+  "bugs": "https://github.com/suitcss/components-button/labels/bug",
+  "license": "MIT",
+  "author": "Nicolas Gallagher",
   "files": [
     "index.css",
     "lib"
   ],
-  "devDependencies": {
-    "stylelint-config-suitcss": "^4.0.0",
-    "suitcss-components-test": "*",
-    "suitcss-preprocessor": "^1.0.1"
+  "style": "index.css",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/suitcss/components-button.git"
   },
-  "license": "MIT",
   "scripts": {
     "build": "npm run setup && npm run preprocess",
     "build-test": "npm run setup && npm run preprocess-test",
@@ -23,15 +32,9 @@
     "watch": "npm run preprocess-test -- -w -v",
     "test": "npm run lint"
   },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/suitcss/components-button.git"
-  },
-  "keywords": [
-    "browser",
-    "css-components",
-    "button",
-    "suitcss",
-    "style"
-  ]
+  "devDependencies": {
+    "stylelint-config-suitcss": "^4.0.0",
+    "suitcss-components-test": "*",
+    "suitcss-preprocessor": "^1.0.1"
+  }
 }


### PR DESCRIPTION
I noticed some inconsistencies and omissions in suit package info, so I tidied up:
- Arrange the package objects to match the order found in https://docs.npmjs.com/files/package.json.
- Add a `homepage` object with a link to the project’s readme on GitHub.
- Add a `bugs` object with a link to the project’s issues labeled `bug` on GitHub.
- Add an `author` object with the name of the project’s author.
- Clean up any mistakes or omissions
