### PR TITLE
Add support for JS bundling

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+require('./lib/button.css');

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "author": "Nicolas Gallagher",
   "files": [
     "index.css",
+    "index.js",
     "lib"
   ],
   "style": "index.css",


### PR DESCRIPTION
Currently unable to load this through CRA's bundling, unlike things like [utils-text](https://github.com/suitcss/utils-text/).