### PR TITLE
Remove macOS Chrome border radius

### DIFF
--- a/lib/button.css
+++ b/lib/button.css
@@ -26,6 +26,7 @@
 .Button {
   background: transparent;
   border-color: var(--Button-border-color);
+  border-radius: 0;
   border-style: solid;
   border-width: var(--Button-border-width);
   box-sizing: border-box; /* 1 */


### PR DESCRIPTION
See: https://github.com/twbs/bootstrap/issues/24093

**Before:**
![before screenshot](https://i.imgur.com/t3vA9fV.png)

**After:**
![after screenshot](https://i.imgur.com/ZJ7vmu9.png)